### PR TITLE
Ensure teams are shown in correct order

### DIFF
--- a/resources/views/my-leagues/view.blade.php
+++ b/resources/views/my-leagues/view.blade.php
@@ -47,7 +47,7 @@
                     </tr>
                     </thead>
                     <tbody>
-                    @foreach($league->teams as $team)
+                    @foreach($league->teams->sortBy('position') as $team)
                         <tr>
                             <th scope="row">
                                 @isset($team->position)


### PR DESCRIPTION
Sort teams on 'View League' page in ascending order by position.