### PR TITLE
Fix typo causing only 10 points to be added to prediction record

### DIFF
--- a/app/Console/Commands/GetResults.php
+++ b/app/Console/Commands/GetResults.php
@@ -92,7 +92,7 @@ class GetResults extends Command
                 $prediction->user->increment('monthly_points', 20);
                 $prediction->user->increment('season_points', 20);
 
-                $prediction->points_awarded = 10;
+                $prediction->points_awarded = 20;
 
                 foreach($prediction->user->teams as $team){
                     $team->increment('points', 20);


### PR DESCRIPTION
Only 10 points, as opposed to 20, would be added to the prediction record if the user's prediction selected the correct score - all other increments had the correct value.